### PR TITLE
chore: CHARTS-3889 Update all embedding urls

### DIFF
--- a/examples/authenticated-custom-jwt/app.js
+++ b/examples/authenticated-custom-jwt/app.js
@@ -24,7 +24,7 @@ app.post("/login", (req, res) => {
     loginDetails.password === mockedPassword
   ) {
     let token = jwt.sign({ username: loginDetails.username }, config.secret, {
-      expiresIn: "24h" // expires in 24 hours
+      expiresIn: "12h" // expires in 12 hours
     });
     res.json({ bearerToken: token });
   } else {

--- a/examples/authenticated-custom-jwt/src/index.js
+++ b/examples/authenticated-custom-jwt/src/index.js
@@ -50,13 +50,13 @@ async function login(username, password) {
  */
 async function renderChart() {
   const sdk = new ChartsEmbedSDK({
-    baseUrl: "https://charts-dev.mongodb.com/charts-test2-pebbp", // Optional: ~REPLACE~ with the Base URL from your Embed Chart dialog
+    baseUrl: "https://charts.mongodb.com/charts-embedding-examples-wgffp", // Optional: ~REPLACE~ with the Base URL from your Embed Chart dialog
     getUserToken: async function() {
       return await login(getUser(), getPass());
     }
   });
 
-  const chart = sdk.createChart({ chartId: "a2e775e6-f267-4c2c-a65d-fbf3fad4a4f2" }); // Optional: ~REPLACE~ with the Chart ID from your Embed Chart dialog
+  const chart = sdk.createChart({ chartId: "8d4dff93-e7ca-4ccd-a622-e20e8a100197" }); // Optional: ~REPLACE~ with the Chart ID from your Embed Chart dialog
 
   // render the chart into a container
   chart.render(document.getElementById("chart"));

--- a/examples/authenticated-google/index.html
+++ b/examples/authenticated-google/index.html
@@ -25,14 +25,13 @@
         const id_token = googleUser.getAuthResponse().id_token;
         const ChartsEmbedSDK = window.ChartsEmbedSDK;
 
-        console.log("ID TOKEN == " + id_token);
         const sdk = new ChartsEmbedSDK({
-          baseUrl: "https://charts-dev.mongodb.com/charts-test2-pebbp", // Optional: ~REPLACE~ with your Charts URL
+          baseUrl: "https://charts.mongodb.com/charts-embedding-examples-wgffp", // Optional: ~REPLACE~ with your Charts URL
           getUserToken: () => id_token,
         });
 
         const chart = sdk.createChart({
-          chartId: "0d984f0c-5f1b-4711-9e5d-f78aa1ea8fcb", // Optional: ~REPLACE~ with your Chart ID
+          chartId: "8d4dff93-e7ca-4ccd-a622-e20e8a100197", // Optional: ~REPLACE~ with your Chart ID
         });
 
         document.body.classList.toggle("logged-in", true);

--- a/examples/authenticated-realm/readme.md
+++ b/examples/authenticated-realm/readme.md
@@ -126,7 +126,7 @@ Your provider config, (ignoring the completed optional settings) should look som
 If you do not wish to use our sample data and have completed the above steps to prepare your own chart for embedding,
 
 - Open the _index.js_ file (`src/index.js`)
-- Replace the Realm `baseUrl` string with the base URL for your Realm app
+- Replace the Realm `AppClientID` string with the base URL for your Realm app (look for "\~REPLACE\~" in the comments)
 - Replace the Charts `baseUrl` string with the base URL you copied from the MongoDB Charts Embedded Chart menu (look for "\~REPLACE\~" in the comments)
 - Replace the `chartId` string with the chart ID you copied from the MongoDB Charts Embedded Chart menu (look for "\~REPLACE\~" in the comments)
 - Replace the Stitch App ID in the Stitch Constructor, and remove the base URL. `Stitch.initializeAppClient('<your-app-id>')`

--- a/examples/authenticated-realm/src/index.js
+++ b/examples/authenticated-realm/src/index.js
@@ -3,10 +3,7 @@ import { Stitch, UserPasswordCredential } from 'mongodb-stitch-browser-sdk'
 import "regenerator-runtime/runtime";
 
 const client = Stitch.initializeAppClient(
-  'realm-authentication-sample-eibkj', // Optional: ~REPLACE~ with your Realm App ID
-  { 
-    baseUrl: 'https://stitch-dev.mongodb.com' // Optional: ~REPLACE~ with your Realm URL
-  }
+  'charts-embedding-sdk-nsuat', // Optional: ~REPLACE~ with your Realm App ID
 ); 
 
 function getUser() {
@@ -38,12 +35,12 @@ async function tryLogin() {
   client.auth.loginWithCredential(credential).then(() =>
   {
     const sdk = new ChartsEmbedSDK({
-      baseUrl: "https://charts-dev.mongodb.com/charts-test2-pebbp", // Optional: ~REPLACE~ with your Charts URL
+      baseUrl: "https://charts.mongodb.com/charts-embedding-examples-wgffp", // Optional: ~REPLACE~ with your Charts URL
       getUserToken: () => getRealmUserToken(client),
     });
 
     const chart = sdk.createChart({
-      chartId: "a2e775e6-f267-4c2c-a65d-fbf3fad4a4f2", // Optional: ~REPLACE~ with your Chart ID
+      chartId: "e966910a-563d-40af-a0e6-57f9d7824c12", // Optional: ~REPLACE~ with your Chart ID
     });
 
     chart.render(document.getElementById("chart"));


### PR DESCRIPTION
## JIRA ticket link

:chart_with_upwards_trend: task: [CHARTS-3889](https://jira.mongodb.org/browse/CHARTS-3889)

## Description

Updated all embedding URL's to refer to a production environment. This includes all Charts embedding base URL's and the Stitch base url in the Realm sample. Since we don't use the develop url for Realm, we no longer need to update the base URL so I removed that instruction from the Readme, along with the line of code it referred to. 