### PR TITLE
chore: CHARTS-5035 update the click event examples

### DIFF
--- a/examples/click-events-basic/package-lock.json
+++ b/examples/click-events-basic/package-lock.json
@@ -986,25 +986,26 @@
       "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg=="
     },
     "@looker/chatty": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@looker/chatty/-/chatty-2.2.0.tgz",
-      "integrity": "sha512-+4KJI0ACVFX/r7KY4MyTXOqbEq0sSV+n8N2hRA0Kq+FJ6VxM5PpwSG8R5QEe4MuT3hNMV3H/kkX2NlFMvtnS8w==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@looker/chatty/-/chatty-2.3.0.tgz",
+      "integrity": "sha512-UO7pwQ+KU4UoV3+MSq7YVnWR74Pl1Jj15QO821W8Y+pW431KoHydiA7UUJmQnPEJDCgHLxepPs43jvJI/NMRhQ==",
       "requires": {
-        "core-js": "^3.1.4",
+        "core-js": "^3.6.4",
         "debug": "^2.2.0",
-        "es6-promise": "^4.2.5"
+        "es6-promise": "^4.2.8"
       }
     },
     "@mongodb-js/charts-embed-dom": {
-      "version": "1.2.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/charts-embed-dom/-/charts-embed-dom-1.2.0-beta.1.tgz",
-      "integrity": "sha512-YXxnqNAZfKqbV0N3m0/Oruavfq9sIo/M6pgc8zs8K16oc5TOYybdcEUPmZdzn9Lv3lhxV9vxwyD3CTLemvpPCw==",
+      "version": "2.1.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/charts-embed-dom/-/charts-embed-dom-2.1.0-beta.1.tgz",
+      "integrity": "sha512-eoDdX2Hcx2WgTt6G1gi2oU1YksQeUyq5v5KdfMD7NJcHOkWR1IIfhtziSNJIDAYRsaQxgUmOEDCpcz5tRV7tsw==",
       "requires": {
-        "@babel/runtime": "^7.10.4",
+        "@babel/runtime": "^7.12.13",
         "@looker/chatty": "^2.2.0",
         "@types/bson": "^4.0.1",
         "bson": "^4.0.2",
-        "jsonwebtoken": "^8.5.1"
+        "jsonwebtoken": "^8.5.1",
+        "lodash": "^4.17.19"
       }
     },
     "@mrmlnc/readdir-enhanced": {
@@ -1075,9 +1076,9 @@
       }
     },
     "@types/node": {
-      "version": "14.14.25",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.25.tgz",
-      "integrity": "sha512-EPpXLOVqDvisVxtlbvzfyqSsFeQxltFbluZNRndIb8tr9KiBnYNLzrc1N3pyKUCww2RNrfHDViqDWWE1LCJQtQ=="
+      "version": "14.14.37",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.37.tgz",
+      "integrity": "sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw=="
     },
     "@types/q": {
       "version": "1.5.4",
@@ -1598,9 +1599,9 @@
       }
     },
     "bson": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.2.2.tgz",
-      "integrity": "sha512-9fX257PVHAUpiRGmY3356RVWKQxLA73BgjA/x5MGuJkTEMeG7yzjuBrsiFB67EXRJnFVKrbJY9t/M+oElKYktQ==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.2.3.tgz",
+      "integrity": "sha512-3ztgjpKp0itFxGqzrLMHWqyZH5oMOIRWsjeY61yNVzrDGB/KxtgD6djFlz9n3vx7lLr2r6bkHagBCgyk1ZjETA==",
       "requires": {
         "buffer": "^5.6.0"
       }
@@ -1913,9 +1914,9 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
     "core-js": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.8.3.tgz",
-      "integrity": "sha512-KPYXeVZYemC2TkNEkX/01I+7yd+nX3KddKwZ1Ww7SKWdI2wQprSgLmrTddT8nw92AjEklTsPBoSdQBhbI1bQ6Q=="
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.9.1.tgz",
+      "integrity": "sha512-gSjRvzkxQc1zjM/5paAmL4idJBFzuJoo+jDjF1tStYFMV2ERfD02HhahhCGXUyHxQRG4yFKVSdO6g62eoRMcDg=="
     },
     "core-js-compat": {
       "version": "3.8.3",

--- a/examples/click-events-basic/package.json
+++ b/examples/click-events-basic/package.json
@@ -8,7 +8,7 @@
     "build": "parcel build index.html"
   },
   "dependencies": {
-    "@mongodb-js/charts-embed-dom": "^1.2.0-beta.1",
+    "@mongodb-js/charts-embed-dom": "^2.1.0-beta.1",
     "regenerator-runtime": "^0.13.3",
     "parcel": "^1.12.4"
   },

--- a/examples/click-events-basic/src/index.js
+++ b/examples/click-events-basic/src/index.js
@@ -2,16 +2,17 @@ import "regenerator-runtime/runtime";
 import ChartsEmbedSDK from "@mongodb-js/charts-embed-dom";
 
 const sdk = new ChartsEmbedSDK({
-  baseUrl: "https://charts.mongodb.com/charts-embedding-examples-wgffp" // Optional: ~REPLACE~ with the Base URL from your Embed Chart dialog
+  baseUrl: "https://charts.mongodb.com/charts-embedding-examples-wgffp", // Optional: ~REPLACE~ with the Base URL from your Embed Chart dialog
 });
 
 const chart = sdk.createChart({
   chartId: "90a8fe84-dd27-4d53-a3fc-0e40392685dd", // Optional: ~REPLACE~ with the Chart ID from your Embed Chart dialog
-  height: "700px"
+  height: "700px",
 });
 
-chart.addEventListener("click", (payload) => {
-  document.getElementById("payload").innerHTML = '<pre>' + JSON.stringify(payload, null, 2) + '</pre>'; 
+const clickHandler = (payload) => {
+  document.getElementById("payload").innerHTML =
+    "<pre>" + JSON.stringify(payload, null, 2) + "</pre>";
 
   let infoText = "";
   if (payload.target.role) {
@@ -36,10 +37,11 @@ chart.addEventListener("click", (payload) => {
   }
 
   document.getElementById("info").innerHTML = "<ul>" + infoText + "</ul>";
-});
+};
 
 async function renderCharts() {
   await chart.render(document.getElementById("chart"));
+  await chart.addEventListener("click", clickHandler);
 }
 
 renderCharts().catch((e) => window.alert(e.message));

--- a/examples/click-events-filtering/package-lock.json
+++ b/examples/click-events-filtering/package-lock.json
@@ -986,25 +986,26 @@
       "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg=="
     },
     "@looker/chatty": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@looker/chatty/-/chatty-2.2.0.tgz",
-      "integrity": "sha512-+4KJI0ACVFX/r7KY4MyTXOqbEq0sSV+n8N2hRA0Kq+FJ6VxM5PpwSG8R5QEe4MuT3hNMV3H/kkX2NlFMvtnS8w==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@looker/chatty/-/chatty-2.3.0.tgz",
+      "integrity": "sha512-UO7pwQ+KU4UoV3+MSq7YVnWR74Pl1Jj15QO821W8Y+pW431KoHydiA7UUJmQnPEJDCgHLxepPs43jvJI/NMRhQ==",
       "requires": {
-        "core-js": "^3.1.4",
+        "core-js": "^3.6.4",
         "debug": "^2.2.0",
-        "es6-promise": "^4.2.5"
+        "es6-promise": "^4.2.8"
       }
     },
     "@mongodb-js/charts-embed-dom": {
-      "version": "1.2.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/charts-embed-dom/-/charts-embed-dom-1.2.0-beta.1.tgz",
-      "integrity": "sha512-YXxnqNAZfKqbV0N3m0/Oruavfq9sIo/M6pgc8zs8K16oc5TOYybdcEUPmZdzn9Lv3lhxV9vxwyD3CTLemvpPCw==",
+      "version": "2.1.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/charts-embed-dom/-/charts-embed-dom-2.1.0-beta.1.tgz",
+      "integrity": "sha512-eoDdX2Hcx2WgTt6G1gi2oU1YksQeUyq5v5KdfMD7NJcHOkWR1IIfhtziSNJIDAYRsaQxgUmOEDCpcz5tRV7tsw==",
       "requires": {
-        "@babel/runtime": "^7.10.4",
+        "@babel/runtime": "^7.12.13",
         "@looker/chatty": "^2.2.0",
         "@types/bson": "^4.0.1",
         "bson": "^4.0.2",
-        "jsonwebtoken": "^8.5.1"
+        "jsonwebtoken": "^8.5.1",
+        "lodash": "^4.17.19"
       }
     },
     "@mrmlnc/readdir-enhanced": {
@@ -1075,9 +1076,9 @@
       }
     },
     "@types/node": {
-      "version": "14.14.25",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.25.tgz",
-      "integrity": "sha512-EPpXLOVqDvisVxtlbvzfyqSsFeQxltFbluZNRndIb8tr9KiBnYNLzrc1N3pyKUCww2RNrfHDViqDWWE1LCJQtQ=="
+      "version": "14.14.37",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.37.tgz",
+      "integrity": "sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw=="
     },
     "@types/q": {
       "version": "1.5.4",
@@ -1598,9 +1599,9 @@
       }
     },
     "bson": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.2.2.tgz",
-      "integrity": "sha512-9fX257PVHAUpiRGmY3356RVWKQxLA73BgjA/x5MGuJkTEMeG7yzjuBrsiFB67EXRJnFVKrbJY9t/M+oElKYktQ==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.2.3.tgz",
+      "integrity": "sha512-3ztgjpKp0itFxGqzrLMHWqyZH5oMOIRWsjeY61yNVzrDGB/KxtgD6djFlz9n3vx7lLr2r6bkHagBCgyk1ZjETA==",
       "requires": {
         "buffer": "^5.6.0"
       }
@@ -1913,9 +1914,9 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
     "core-js": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.8.3.tgz",
-      "integrity": "sha512-KPYXeVZYemC2TkNEkX/01I+7yd+nX3KddKwZ1Ww7SKWdI2wQprSgLmrTddT8nw92AjEklTsPBoSdQBhbI1bQ6Q=="
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.9.1.tgz",
+      "integrity": "sha512-gSjRvzkxQc1zjM/5paAmL4idJBFzuJoo+jDjF1tStYFMV2ERfD02HhahhCGXUyHxQRG4yFKVSdO6g62eoRMcDg=="
     },
     "core-js-compat": {
       "version": "3.8.3",

--- a/examples/click-events-filtering/package.json
+++ b/examples/click-events-filtering/package.json
@@ -8,7 +8,7 @@
     "build": "parcel build index.html"
   },
   "dependencies": {
-    "@mongodb-js/charts-embed-dom": "^1.2.0-beta.1",
+    "@mongodb-js/charts-embed-dom": "^2.1.0-beta.1",
     "regenerator-runtime": "^0.13.3",
     "parcel": "^1.12.4"
   },

--- a/examples/click-events-filtering/src/index.js
+++ b/examples/click-events-filtering/src/index.js
@@ -2,41 +2,33 @@ import "regenerator-runtime/runtime";
 import ChartsEmbedSDK from "@mongodb-js/charts-embed-dom";
 
 const sdk = new ChartsEmbedSDK({
-  baseUrl: "https://charts.mongodb.com/charts-embedding-examples-wgffp" // Optional: ~REPLACE~ with the Base URL from your Embed Chart dialog
+  baseUrl: "https://charts.mongodb.com/charts-embedding-examples-wgffp", // Optional: ~REPLACE~ with the Base URL from your Embed Chart dialog
 });
 
 const chart1 = sdk.createChart({
   chartId: "90a8fe84-dd27-4d53-a3fc-0e40392685dd", // Optional: ~REPLACE~ with the Chart ID from your Embed Chart dialog
-  height: "700px"
+  height: "700px",
 });
 
 const chart2 = sdk.createChart({
   chartId: "c6d6b83e-b096-4bb8-9d7f-b7344177cd11", // Optional: ~REPLACE~ with the Chart ID from your Embed Chart dialog
-  height: "700px"
+  height: "700px",
 });
 
-chart1.addEventListener("click", (payload) => {
-  if (payload.target.role === "mark") {
-    // Optional: ~REPLACE~ this with a suitable filter if you're using your own chart
-    const filter = {
-      genres: payload.data.y.value,
-      year: {
-        $gte: payload.data.color.lowerBound,
-        $lt: payload.data.color.upperBound
-      }
-    };
-    chart2.setFilter(filter);
-    document.getElementById("filterMessage").innerText = `${payload.data.y.value} movies from the ${payload.data.color.lowerBound}s`
-
-  } else {
-    chart2.setFilter({});
-    document.getElementById("filterMessage").innerText = "all movies"
-  }
-});
+const clickHandler = (payload) => {
+  // Optional: ~REPLACE~ this with a suitable filter if you're using your own chart
+  chart2.setFilter(payload.selectionFilter);
+  document.getElementById(
+    "filterMessage"
+  ).innerText = `${payload.data.y.value} movies from the ${payload.data.color.lowerBound}s`;
+};
 
 async function renderCharts() {
   await chart1.render(document.getElementById("chart1"));
   await chart2.render(document.getElementById("chart2"));
+
+  const options = { includes: [{ roles: ["mark"] }] };
+  await chart1.addEventListener("click", clickHandler, options);
 }
 
 renderCharts().catch((e) => window.alert(e.message));


### PR DESCRIPTION
Updating the existing examples for the click events to use the new SDK package beta version.
The calls for `addEventListener` are moved after the chart render call as we need to establish a connection first between the SDK and the Charts instance.
