### PR TITLE
chore: removing the regenerator package for the click examples

### DIFF
--- a/examples/click-events-basic/package.json
+++ b/examples/click-events-basic/package.json
@@ -9,7 +9,6 @@
   },
   "dependencies": {
     "@mongodb-js/charts-embed-dom": "^2.1.0-beta.1",
-    "regenerator-runtime": "^0.13.3",
     "parcel": "^1.12.4"
   },
   "devDependencies": {
@@ -17,5 +16,8 @@
     "@babel/preset-env": "^7.8.4",
     "parcel-bundler": "^1.6.1"
   },
-  "keywords": []
+  "keywords": [],
+  "browserslist": [
+    "since 2020"
+  ]
 }

--- a/examples/click-events-basic/src/index.js
+++ b/examples/click-events-basic/src/index.js
@@ -1,4 +1,3 @@
-import "regenerator-runtime/runtime";
 import ChartsEmbedSDK from "@mongodb-js/charts-embed-dom";
 
 const sdk = new ChartsEmbedSDK({

--- a/examples/click-events-filtering/package.json
+++ b/examples/click-events-filtering/package.json
@@ -9,7 +9,6 @@
   },
   "dependencies": {
     "@mongodb-js/charts-embed-dom": "^2.1.0-beta.1",
-    "regenerator-runtime": "^0.13.3",
     "parcel": "^1.12.4"
   },
   "devDependencies": {
@@ -17,5 +16,8 @@
     "@babel/preset-env": "^7.8.4",
     "parcel-bundler": "^1.6.1"
   },
-  "keywords": []
+  "keywords": [],
+  "browserslist": [
+    "since 2020"
+  ]
 }

--- a/examples/click-events-filtering/readme.md
+++ b/examples/click-events-filtering/readme.md
@@ -13,13 +13,14 @@ When you embed charts using the Embedding SDK, you are able to subscribe to even
 #### The features included in this demo are as follows:
 
 - Adding a click event handler to a chart, using code similar to:
+
 ```
-chart.addEventListener("click", callback);
+chart.addEventListener("click", callback, options);
 ```
-- Parsing the payload returned by the click event to determine if the event's `target` is of type `mark`
+
+- Adding an option to make just certain parts of the chart clickable (in this case only the bars)
 - Generating an MQL filter document based on the data returned in the payload
 - Filtering a second chart using the `setFilter` method
-
 
 ## Quickstart
 
@@ -60,6 +61,7 @@ This sample is preconfigured to render a specific chart. You can run the sample 
 ## Running this Sample with your data
 
 1. If you do not wish to use our sample data and have completed the above steps to prepare your own chart for embedding,
+
    - Open the _index.js_ file (`src/index.js`)
    - Replace the `baseUrl` string on with the base URL you copied from the MongoDB Charts Embedded Chart menu (look for "\~REPLACE\~" in the comments)
    - Replace the `chartId` string on with the chart ID you copied from the MongoDB Charts Embedded Chart menu (look for "\~REPLACE\~" in the comments)

--- a/examples/click-events-filtering/src/index.js
+++ b/examples/click-events-filtering/src/index.js
@@ -1,4 +1,3 @@
-import "regenerator-runtime/runtime";
 import ChartsEmbedSDK from "@mongodb-js/charts-embed-dom";
 
 const sdk = new ChartsEmbedSDK({


### PR DESCRIPTION
- Removing the regenerator package from the package.json for the click event examples
- Updating the readme for the the click-events-filtering example