### PR TITLE
chore/CHARTS remove regenerator package from examples

### DIFF
--- a/examples/authenticated-google/index.html
+++ b/examples/authenticated-google/index.html
@@ -38,7 +38,6 @@
         chart.render(document.getElementById("chart"));
       }
     </script>
-    <script type="text/javascript" src="src/index.js"></script>
     <main>
       <h1 id="lock"></h1>
       <div id="login-page" class="login-page">

--- a/examples/authenticated-google/package.json
+++ b/examples/authenticated-google/package.json
@@ -8,12 +8,14 @@
     "build": "parcel build index.html"
   },
   "dependencies": {
-    "parcel": "^1.12.4",
-    "regenerator-runtime": "^0.13.5"
+    "parcel": "^1.12.4"
   },
   "devDependencies": {
     "@babel/core": "^7.8.6",
     "@babel/preset-env": "^7.8.6",
     "parcel-bundler": "^1.6.1"
-  }
+  },
+  "browserslist": [
+    "since 2020"
+  ]
 }

--- a/examples/authenticated-google/src/index.js
+++ b/examples/authenticated-google/src/index.js
@@ -1,1 +1,0 @@
-import "regenerator-runtime/runtime";

--- a/examples/authenticated-realm/package.json
+++ b/examples/authenticated-realm/package.json
@@ -12,12 +12,14 @@
     "jsonwebtoken": "^8.3.0",
     "mongodb-stitch-browser-sdk": "^4.8.0",
     "parcel": "^1.12.4",
-    "regenerator-runtime": "^0.13.3",
     "request": "^2.88.2"
   },
   "devDependencies": {
     "@babel/core": "^7.8.6",
     "@babel/preset-env": "^7.8.6",
     "parcel-bundler": "^1.6.1"
-  }
+  },
+  "browserslist": [
+    "since 2020"
+  ]
 }

--- a/examples/authenticated-realm/src/index.js
+++ b/examples/authenticated-realm/src/index.js
@@ -1,6 +1,5 @@
 import ChartsEmbedSDK, { getRealmUserToken }from "@mongodb-js/charts-embed-dom";
 import { Stitch, UserPasswordCredential } from 'mongodb-stitch-browser-sdk'
-import "regenerator-runtime/runtime";
 
 const client = Stitch.initializeAppClient(
   'charts-embedding-sdk-nsuat', // Optional: ~REPLACE~ with your Realm App ID


### PR DESCRIPTION
Removing the regenerator package from google and realm auth examples as the code-sandbox has issues with the package version.

Examples still work:

Google auth example:
<img width="1669" alt="Screen Shot 2021-04-19 at 12 20 47 pm" src="https://user-images.githubusercontent.com/51065986/115174020-cd89bb80-a10b-11eb-9ffe-05b56e31139a.png">

Realm auth example
<img width="1676" alt="Screen Shot 2021-04-19 at 12 24 15 pm" src="https://user-images.githubusercontent.com/51065986/115174079-ebefb700-a10b-11eb-8786-bfef75ad3a61.png">

Realm auth in sandbox:

![Screen Shot 2021-04-19 at 12 46 55 pm](https://user-images.githubusercontent.com/51065986/115174879-6b31ba80-a10d-11eb-9f44-c679e4d9fb91.png)

