### PR TITLE
Update embedding SDK samples to use v2.1.0

### DIFF
--- a/examples/authenticated-custom-jwt/package-lock.json
+++ b/examples/authenticated-custom-jwt/package-lock.json
@@ -986,25 +986,26 @@
       "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg=="
     },
     "@looker/chatty": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@looker/chatty/-/chatty-2.2.0.tgz",
-      "integrity": "sha512-+4KJI0ACVFX/r7KY4MyTXOqbEq0sSV+n8N2hRA0Kq+FJ6VxM5PpwSG8R5QEe4MuT3hNMV3H/kkX2NlFMvtnS8w==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@looker/chatty/-/chatty-2.3.0.tgz",
+      "integrity": "sha512-UO7pwQ+KU4UoV3+MSq7YVnWR74Pl1Jj15QO821W8Y+pW431KoHydiA7UUJmQnPEJDCgHLxepPs43jvJI/NMRhQ==",
       "requires": {
-        "core-js": "^3.1.4",
+        "core-js": "^3.6.4",
         "debug": "^2.2.0",
-        "es6-promise": "^4.2.5"
+        "es6-promise": "^4.2.8"
       }
     },
     "@mongodb-js/charts-embed-dom": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/charts-embed-dom/-/charts-embed-dom-2.0.0.tgz",
-      "integrity": "sha512-nRkMUL5amioF70QAFYYQc7vCOmCSsjpfh5cM9+yRaRgn+jh9POpzYU4XLc/WYPG2Fjn/WTKSmbJ3evvMf9r4Xg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/charts-embed-dom/-/charts-embed-dom-2.1.0.tgz",
+      "integrity": "sha512-F3/8lzmEUgcm5JdXRVsRzIuUgnO5DQvGrL39R6mtPOAUYhSF5zIXXF9cyuyQ1ti96aWLL35LJOzaAlh3CE0pXg==",
       "requires": {
-        "@babel/runtime": "^7.10.4",
+        "@babel/runtime": "^7.12.13",
         "@looker/chatty": "^2.2.0",
         "@types/bson": "^4.0.1",
-        "bson": "^4.0.2",
-        "jsonwebtoken": "^8.5.1"
+        "bson": "4.0.2",
+        "jsonwebtoken": "^8.5.1",
+        "lodash": "^4.17.19"
       }
     },
     "@mrmlnc/readdir-enhanced": {
@@ -1067,17 +1068,17 @@
       }
     },
     "@types/bson": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.3.tgz",
-      "integrity": "sha512-mVRvYnTOZJz3ccpxhr3wgxVmSeiYinW+zlzQz3SXWaJmD1DuL05Jeq7nKw3SnbKmbleW5qrLG5vdyWe/A9sXhw==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.5.tgz",
+      "integrity": "sha512-vVLwMUqhYJSQ/WKcE60eFqcyuWse5fGH+NMAXHuKrUAPoryq3ATxk5o4bgYNtg5aOM4APVg7Hnb3ASqUYG0PKg==",
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/node": {
-      "version": "14.14.25",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.25.tgz",
-      "integrity": "sha512-EPpXLOVqDvisVxtlbvzfyqSsFeQxltFbluZNRndIb8tr9KiBnYNLzrc1N3pyKUCww2RNrfHDViqDWWE1LCJQtQ=="
+      "version": "16.4.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.10.tgz",
+      "integrity": "sha512-TmVHsm43br64js9BqHWqiDZA+xMtbUpI1MBIA0EyiBmoV9pcEYFOSdj5fr6enZNfh4fChh+AGOLIzGwJnkshyQ=="
     },
     "@types/q": {
       "version": "1.5.4",
@@ -1634,11 +1635,12 @@
       }
     },
     "bson": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.2.2.tgz",
-      "integrity": "sha512-9fX257PVHAUpiRGmY3356RVWKQxLA73BgjA/x5MGuJkTEMeG7yzjuBrsiFB67EXRJnFVKrbJY9t/M+oElKYktQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.0.2.tgz",
+      "integrity": "sha512-rBdCxMBCg2aR420e1oKUejjcuPZLTibA7zEhWAlliFWEwzuBCC9Dkp5r7VFFIQB2t1WVsvTbohry575mc7Xw5A==",
       "requires": {
-        "buffer": "^5.6.0"
+        "buffer": "^5.1.0",
+        "long": "^4.0.0"
       }
     },
     "buffer": {
@@ -1984,9 +1986,9 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
     "core-js": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.8.3.tgz",
-      "integrity": "sha512-KPYXeVZYemC2TkNEkX/01I+7yd+nX3KddKwZ1Ww7SKWdI2wQprSgLmrTddT8nw92AjEklTsPBoSdQBhbI1bQ6Q=="
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.0.tgz",
+      "integrity": "sha512-5+5VxRFmSf97nM8Jr2wzOwLqRo6zphH2aX+7KsAUONObyzakDNq2G/bgbhinxB4PoV9L3aXQYhiDKyIKWd2c8g=="
     },
     "core-js-compat": {
       "version": "3.8.3",
@@ -3973,6 +3975,11 @@
       "requires": {
         "chalk": "^2.0.1"
       }
+    },
+    "long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
     "magic-string": {
       "version": "0.22.5",

--- a/examples/authenticated-custom-jwt/package.json
+++ b/examples/authenticated-custom-jwt/package.json
@@ -8,7 +8,7 @@
     "build": "parcel build index.html"
   },
   "dependencies": {
-    "@mongodb-js/charts-embed-dom": "^2.0.1",
+    "@mongodb-js/charts-embed-dom": "^2.1.0",
     "cors": "^2.8.5",
     "express": "^4.16.3",
     "jsonwebtoken": "^8.3.0",

--- a/examples/authenticated-realm/package-lock.json
+++ b/examples/authenticated-realm/package-lock.json
@@ -986,25 +986,26 @@
       "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg=="
     },
     "@looker/chatty": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@looker/chatty/-/chatty-2.2.0.tgz",
-      "integrity": "sha512-+4KJI0ACVFX/r7KY4MyTXOqbEq0sSV+n8N2hRA0Kq+FJ6VxM5PpwSG8R5QEe4MuT3hNMV3H/kkX2NlFMvtnS8w==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@looker/chatty/-/chatty-2.3.0.tgz",
+      "integrity": "sha512-UO7pwQ+KU4UoV3+MSq7YVnWR74Pl1Jj15QO821W8Y+pW431KoHydiA7UUJmQnPEJDCgHLxepPs43jvJI/NMRhQ==",
       "requires": {
-        "core-js": "^3.1.4",
+        "core-js": "^3.6.4",
         "debug": "^2.2.0",
-        "es6-promise": "^4.2.5"
+        "es6-promise": "^4.2.8"
       }
     },
     "@mongodb-js/charts-embed-dom": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/charts-embed-dom/-/charts-embed-dom-2.0.1.tgz",
-      "integrity": "sha512-xd5PeWk7ds3K9Sv2HbpHumsbPmsXTBQXYtBedx18pz9y7AbTM83RjEvmF+5D0h3F+ZtGzNFGzE782oaWTxS1NQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/charts-embed-dom/-/charts-embed-dom-2.1.0.tgz",
+      "integrity": "sha512-F3/8lzmEUgcm5JdXRVsRzIuUgnO5DQvGrL39R6mtPOAUYhSF5zIXXF9cyuyQ1ti96aWLL35LJOzaAlh3CE0pXg==",
       "requires": {
-        "@babel/runtime": "^7.10.4",
+        "@babel/runtime": "^7.12.13",
         "@looker/chatty": "^2.2.0",
         "@types/bson": "^4.0.1",
-        "bson": "^4.0.2",
-        "jsonwebtoken": "^8.5.1"
+        "bson": "4.0.2",
+        "jsonwebtoken": "^8.5.1",
+        "lodash": "^4.17.19"
       }
     },
     "@mrmlnc/readdir-enhanced": {
@@ -1067,17 +1068,17 @@
       }
     },
     "@types/bson": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.3.tgz",
-      "integrity": "sha512-mVRvYnTOZJz3ccpxhr3wgxVmSeiYinW+zlzQz3SXWaJmD1DuL05Jeq7nKw3SnbKmbleW5qrLG5vdyWe/A9sXhw==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.5.tgz",
+      "integrity": "sha512-vVLwMUqhYJSQ/WKcE60eFqcyuWse5fGH+NMAXHuKrUAPoryq3ATxk5o4bgYNtg5aOM4APVg7Hnb3ASqUYG0PKg==",
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/node": {
-      "version": "14.14.25",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.25.tgz",
-      "integrity": "sha512-EPpXLOVqDvisVxtlbvzfyqSsFeQxltFbluZNRndIb8tr9KiBnYNLzrc1N3pyKUCww2RNrfHDViqDWWE1LCJQtQ=="
+      "version": "16.4.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.10.tgz",
+      "integrity": "sha512-TmVHsm43br64js9BqHWqiDZA+xMtbUpI1MBIA0EyiBmoV9pcEYFOSdj5fr6enZNfh4fChh+AGOLIzGwJnkshyQ=="
     },
     "@types/q": {
       "version": "1.5.4",
@@ -1598,11 +1599,12 @@
       }
     },
     "bson": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.2.2.tgz",
-      "integrity": "sha512-9fX257PVHAUpiRGmY3356RVWKQxLA73BgjA/x5MGuJkTEMeG7yzjuBrsiFB67EXRJnFVKrbJY9t/M+oElKYktQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.0.2.tgz",
+      "integrity": "sha512-rBdCxMBCg2aR420e1oKUejjcuPZLTibA7zEhWAlliFWEwzuBCC9Dkp5r7VFFIQB2t1WVsvTbohry575mc7Xw5A==",
       "requires": {
-        "buffer": "^5.6.0"
+        "buffer": "^5.1.0",
+        "long": "^4.0.0"
       }
     },
     "buffer": {
@@ -1913,9 +1915,9 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
     "core-js": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.8.3.tgz",
-      "integrity": "sha512-KPYXeVZYemC2TkNEkX/01I+7yd+nX3KddKwZ1Ww7SKWdI2wQprSgLmrTddT8nw92AjEklTsPBoSdQBhbI1bQ6Q=="
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.0.tgz",
+      "integrity": "sha512-5+5VxRFmSf97nM8Jr2wzOwLqRo6zphH2aX+7KsAUONObyzakDNq2G/bgbhinxB4PoV9L3aXQYhiDKyIKWd2c8g=="
     },
     "core-js-compat": {
       "version": "3.8.3",

--- a/examples/authenticated-realm/package.json
+++ b/examples/authenticated-realm/package.json
@@ -8,7 +8,7 @@
     "build": "parcel build index.html"
   },
   "dependencies": {
-    "@mongodb-js/charts-embed-dom": "^2.0.1",
+    "@mongodb-js/charts-embed-dom": "^2.1.0",
     "jsonwebtoken": "^8.3.0",
     "mongodb-stitch-browser-sdk": "^4.8.0",
     "parcel": "^1.12.4",

--- a/examples/click-events-basic/package-lock.json
+++ b/examples/click-events-basic/package-lock.json
@@ -996,14 +996,14 @@
       }
     },
     "@mongodb-js/charts-embed-dom": {
-      "version": "2.1.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/charts-embed-dom/-/charts-embed-dom-2.1.0-beta.1.tgz",
-      "integrity": "sha512-eoDdX2Hcx2WgTt6G1gi2oU1YksQeUyq5v5KdfMD7NJcHOkWR1IIfhtziSNJIDAYRsaQxgUmOEDCpcz5tRV7tsw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/charts-embed-dom/-/charts-embed-dom-2.1.0.tgz",
+      "integrity": "sha512-F3/8lzmEUgcm5JdXRVsRzIuUgnO5DQvGrL39R6mtPOAUYhSF5zIXXF9cyuyQ1ti96aWLL35LJOzaAlh3CE0pXg==",
       "requires": {
         "@babel/runtime": "^7.12.13",
         "@looker/chatty": "^2.2.0",
         "@types/bson": "^4.0.1",
-        "bson": "^4.0.2",
+        "bson": "4.0.2",
         "jsonwebtoken": "^8.5.1",
         "lodash": "^4.17.19"
       }
@@ -1068,17 +1068,17 @@
       }
     },
     "@types/bson": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.3.tgz",
-      "integrity": "sha512-mVRvYnTOZJz3ccpxhr3wgxVmSeiYinW+zlzQz3SXWaJmD1DuL05Jeq7nKw3SnbKmbleW5qrLG5vdyWe/A9sXhw==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.5.tgz",
+      "integrity": "sha512-vVLwMUqhYJSQ/WKcE60eFqcyuWse5fGH+NMAXHuKrUAPoryq3ATxk5o4bgYNtg5aOM4APVg7Hnb3ASqUYG0PKg==",
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/node": {
-      "version": "14.14.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.37.tgz",
-      "integrity": "sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw=="
+      "version": "16.4.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.10.tgz",
+      "integrity": "sha512-TmVHsm43br64js9BqHWqiDZA+xMtbUpI1MBIA0EyiBmoV9pcEYFOSdj5fr6enZNfh4fChh+AGOLIzGwJnkshyQ=="
     },
     "@types/q": {
       "version": "1.5.4",
@@ -1599,11 +1599,12 @@
       }
     },
     "bson": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.2.3.tgz",
-      "integrity": "sha512-3ztgjpKp0itFxGqzrLMHWqyZH5oMOIRWsjeY61yNVzrDGB/KxtgD6djFlz9n3vx7lLr2r6bkHagBCgyk1ZjETA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.0.2.tgz",
+      "integrity": "sha512-rBdCxMBCg2aR420e1oKUejjcuPZLTibA7zEhWAlliFWEwzuBCC9Dkp5r7VFFIQB2t1WVsvTbohry575mc7Xw5A==",
       "requires": {
-        "buffer": "^5.6.0"
+        "buffer": "^5.1.0",
+        "long": "^4.0.0"
       }
     },
     "buffer": {
@@ -1914,9 +1915,9 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
     "core-js": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.9.1.tgz",
-      "integrity": "sha512-gSjRvzkxQc1zjM/5paAmL4idJBFzuJoo+jDjF1tStYFMV2ERfD02HhahhCGXUyHxQRG4yFKVSdO6g62eoRMcDg=="
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.0.tgz",
+      "integrity": "sha512-5+5VxRFmSf97nM8Jr2wzOwLqRo6zphH2aX+7KsAUONObyzakDNq2G/bgbhinxB4PoV9L3aXQYhiDKyIKWd2c8g=="
     },
     "core-js-compat": {
       "version": "3.8.3",
@@ -3816,6 +3817,11 @@
       "requires": {
         "chalk": "^2.0.1"
       }
+    },
+    "long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
     "magic-string": {
       "version": "0.22.5",

--- a/examples/click-events-basic/package.json
+++ b/examples/click-events-basic/package.json
@@ -8,7 +8,7 @@
     "build": "parcel build index.html"
   },
   "dependencies": {
-    "@mongodb-js/charts-embed-dom": "^2.1.0-beta.1",
+    "@mongodb-js/charts-embed-dom": "^2.1.0",
     "parcel": "^1.12.4"
   },
   "devDependencies": {

--- a/examples/click-events-basic/readme.md
+++ b/examples/click-events-basic/readme.md
@@ -2,8 +2,6 @@
 
 ## Background
 
-⚠ _This example uses Beta functionality which is subject to change before the release. You must use the `@beta` tagged version of `@mongodb-js/charts-embed-dom` to use this functionality._
-
 🎮 _[Play with a live demo of this sample here](https://codesandbox.io/s/github/mongodb-js/charts-embed-sdk/tree/master/examples/click-events-basic)_
 
 MongoDB Charts allows you to create visualizations of your MongoDB data using a simple web interface. You can view the visualizations within the Charts UI, or you can use the Embedding feature to render the charts in an external web application.
@@ -15,6 +13,11 @@ When you embed charts using the Embedding SDK, you are able to subscribe to even
 - Adding a click event handler to a chart, using code similar to:
 ```
 chart.addEventListener("click", callback);
+```
+
+- Highlighting the element clicked on the chart, using the following code:
+```
+chart.setHighlight(payload.selectionFilter)
 ```
 
 - Parsing the payload returned to the callback event. A typical click event's payload will look something like this:

--- a/examples/click-events-basic/src/index.js
+++ b/examples/click-events-basic/src/index.js
@@ -10,6 +10,10 @@ const chart = sdk.createChart({
 });
 
 const clickHandler = (payload) => {
+  // Highlight the clicked element on the chart
+  chart.setHighlight(payload.selectionFilter);
+
+  // Display information about the clicked element
   document.getElementById("payload").innerHTML =
     "<pre>" + JSON.stringify(payload, null, 2) + "</pre>";
 

--- a/examples/click-events-filtering/package-lock.json
+++ b/examples/click-events-filtering/package-lock.json
@@ -996,14 +996,14 @@
       }
     },
     "@mongodb-js/charts-embed-dom": {
-      "version": "2.1.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/charts-embed-dom/-/charts-embed-dom-2.1.0-beta.1.tgz",
-      "integrity": "sha512-eoDdX2Hcx2WgTt6G1gi2oU1YksQeUyq5v5KdfMD7NJcHOkWR1IIfhtziSNJIDAYRsaQxgUmOEDCpcz5tRV7tsw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/charts-embed-dom/-/charts-embed-dom-2.1.0.tgz",
+      "integrity": "sha512-F3/8lzmEUgcm5JdXRVsRzIuUgnO5DQvGrL39R6mtPOAUYhSF5zIXXF9cyuyQ1ti96aWLL35LJOzaAlh3CE0pXg==",
       "requires": {
         "@babel/runtime": "^7.12.13",
         "@looker/chatty": "^2.2.0",
         "@types/bson": "^4.0.1",
-        "bson": "^4.0.2",
+        "bson": "4.0.2",
         "jsonwebtoken": "^8.5.1",
         "lodash": "^4.17.19"
       }
@@ -1068,17 +1068,17 @@
       }
     },
     "@types/bson": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.3.tgz",
-      "integrity": "sha512-mVRvYnTOZJz3ccpxhr3wgxVmSeiYinW+zlzQz3SXWaJmD1DuL05Jeq7nKw3SnbKmbleW5qrLG5vdyWe/A9sXhw==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.5.tgz",
+      "integrity": "sha512-vVLwMUqhYJSQ/WKcE60eFqcyuWse5fGH+NMAXHuKrUAPoryq3ATxk5o4bgYNtg5aOM4APVg7Hnb3ASqUYG0PKg==",
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/node": {
-      "version": "14.14.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.37.tgz",
-      "integrity": "sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw=="
+      "version": "16.4.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.10.tgz",
+      "integrity": "sha512-TmVHsm43br64js9BqHWqiDZA+xMtbUpI1MBIA0EyiBmoV9pcEYFOSdj5fr6enZNfh4fChh+AGOLIzGwJnkshyQ=="
     },
     "@types/q": {
       "version": "1.5.4",
@@ -1599,11 +1599,12 @@
       }
     },
     "bson": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.2.3.tgz",
-      "integrity": "sha512-3ztgjpKp0itFxGqzrLMHWqyZH5oMOIRWsjeY61yNVzrDGB/KxtgD6djFlz9n3vx7lLr2r6bkHagBCgyk1ZjETA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.0.2.tgz",
+      "integrity": "sha512-rBdCxMBCg2aR420e1oKUejjcuPZLTibA7zEhWAlliFWEwzuBCC9Dkp5r7VFFIQB2t1WVsvTbohry575mc7Xw5A==",
       "requires": {
-        "buffer": "^5.6.0"
+        "buffer": "^5.1.0",
+        "long": "^4.0.0"
       }
     },
     "buffer": {
@@ -1914,9 +1915,9 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
     "core-js": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.9.1.tgz",
-      "integrity": "sha512-gSjRvzkxQc1zjM/5paAmL4idJBFzuJoo+jDjF1tStYFMV2ERfD02HhahhCGXUyHxQRG4yFKVSdO6g62eoRMcDg=="
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.0.tgz",
+      "integrity": "sha512-5+5VxRFmSf97nM8Jr2wzOwLqRo6zphH2aX+7KsAUONObyzakDNq2G/bgbhinxB4PoV9L3aXQYhiDKyIKWd2c8g=="
     },
     "core-js-compat": {
       "version": "3.8.3",
@@ -3816,6 +3817,11 @@
       "requires": {
         "chalk": "^2.0.1"
       }
+    },
+    "long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
     "magic-string": {
       "version": "0.22.5",

--- a/examples/click-events-filtering/package.json
+++ b/examples/click-events-filtering/package.json
@@ -8,7 +8,7 @@
     "build": "parcel build index.html"
   },
   "dependencies": {
-    "@mongodb-js/charts-embed-dom": "^2.1.0-beta.1",
+    "@mongodb-js/charts-embed-dom": "^2.1.0",
     "parcel": "^1.12.4"
   },
   "devDependencies": {

--- a/examples/click-events-filtering/readme.md
+++ b/examples/click-events-filtering/readme.md
@@ -2,8 +2,6 @@
 
 ## Background
 
-⚠ _This example uses Beta functionality which is subject to change before the release. You must use the `@beta` tagged version of `@mongodb-js/charts-embed-dom` to use this functionality._
-
 🎮 _[Play with a live demo of this sample here](https://codesandbox.io/s/github/mongodb-js/charts-embed-sdk/tree/master/examples/click-events-filtering)_
 
 MongoDB Charts allows you to create visualizations of your MongoDB data using a simple web interface. You can view the visualizations within the Charts UI, or you can use the Embedding feature to render the charts in an external web application.
@@ -19,7 +17,8 @@ chart.addEventListener("click", callback, options);
 ```
 
 - Adding an option to make just certain parts of the chart clickable (in this case only the bars)
-- Generating an MQL filter document based on the data returned in the payload
+- Obtaining an MQL filter document based on the data returned in the payload using `selectionFilter`
+- Highlighting the clicked element on the first chart using `setHighlight`
 - Filtering a second chart using the `setFilter` method
 
 ## Quickstart

--- a/examples/click-events-filtering/src/index.js
+++ b/examples/click-events-filtering/src/index.js
@@ -15,7 +15,7 @@ const chart2 = sdk.createChart({
 });
 
 const clickHandler = (payload) => {
-  // Optional: ~REPLACE~ this with a suitable filter if you're using your own chart
+  chart1.setHighlight(payload.selectionFilter);
   chart2.setFilter(payload.selectionFilter);
   document.getElementById(
     "filterMessage"

--- a/examples/timeline-charts-example/package-lock.json
+++ b/examples/timeline-charts-example/package-lock.json
@@ -1337,13 +1337,13 @@
       }
     },
     "@looker/chatty": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@looker/chatty/-/chatty-2.2.0.tgz",
-      "integrity": "sha512-+4KJI0ACVFX/r7KY4MyTXOqbEq0sSV+n8N2hRA0Kq+FJ6VxM5PpwSG8R5QEe4MuT3hNMV3H/kkX2NlFMvtnS8w==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@looker/chatty/-/chatty-2.3.0.tgz",
+      "integrity": "sha512-UO7pwQ+KU4UoV3+MSq7YVnWR74Pl1Jj15QO821W8Y+pW431KoHydiA7UUJmQnPEJDCgHLxepPs43jvJI/NMRhQ==",
       "requires": {
-        "core-js": "^3.1.4",
+        "core-js": "^3.6.4",
         "debug": "^2.2.0",
-        "es6-promise": "^4.2.5"
+        "es6-promise": "^4.2.8"
       }
     },
     "@material-ui/core": {
@@ -1415,15 +1415,16 @@
       }
     },
     "@mongodb-js/charts-embed-dom": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/charts-embed-dom/-/charts-embed-dom-2.0.1.tgz",
-      "integrity": "sha512-xd5PeWk7ds3K9Sv2HbpHumsbPmsXTBQXYtBedx18pz9y7AbTM83RjEvmF+5D0h3F+ZtGzNFGzE782oaWTxS1NQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/charts-embed-dom/-/charts-embed-dom-2.1.0.tgz",
+      "integrity": "sha512-F3/8lzmEUgcm5JdXRVsRzIuUgnO5DQvGrL39R6mtPOAUYhSF5zIXXF9cyuyQ1ti96aWLL35LJOzaAlh3CE0pXg==",
       "requires": {
-        "@babel/runtime": "^7.10.4",
+        "@babel/runtime": "^7.12.13",
         "@looker/chatty": "^2.2.0",
         "@types/bson": "^4.0.1",
-        "bson": "^4.0.2",
-        "jsonwebtoken": "^8.5.1"
+        "bson": "4.0.2",
+        "jsonwebtoken": "^8.5.1",
+        "lodash": "^4.17.19"
       }
     },
     "@mrmlnc/readdir-enhanced": {
@@ -1587,9 +1588,9 @@
       }
     },
     "@types/bson": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.3.tgz",
-      "integrity": "sha512-mVRvYnTOZJz3ccpxhr3wgxVmSeiYinW+zlzQz3SXWaJmD1DuL05Jeq7nKw3SnbKmbleW5qrLG5vdyWe/A9sXhw==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.5.tgz",
+      "integrity": "sha512-vVLwMUqhYJSQ/WKcE60eFqcyuWse5fGH+NMAXHuKrUAPoryq3ATxk5o4bgYNtg5aOM4APVg7Hnb3ASqUYG0PKg==",
       "requires": {
         "@types/node": "*"
       }
@@ -3032,11 +3033,12 @@
       }
     },
     "bson": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.2.2.tgz",
-      "integrity": "sha512-9fX257PVHAUpiRGmY3356RVWKQxLA73BgjA/x5MGuJkTEMeG7yzjuBrsiFB67EXRJnFVKrbJY9t/M+oElKYktQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.0.2.tgz",
+      "integrity": "sha512-rBdCxMBCg2aR420e1oKUejjcuPZLTibA7zEhWAlliFWEwzuBCC9Dkp5r7VFFIQB2t1WVsvTbohry575mc7Xw5A==",
       "requires": {
-        "buffer": "^5.6.0"
+        "buffer": "^5.1.0",
+        "long": "^4.0.0"
       }
     },
     "buffer": {
@@ -8088,6 +8090,11 @@
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.7.1.tgz",
       "integrity": "sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw=="
+    },
+    "long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
     "loose-envify": {
       "version": "1.4.0",

--- a/examples/timeline-charts-example/package.json
+++ b/examples/timeline-charts-example/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@material-ui/core": "^4.9.12",
-    "@mongodb-js/charts-embed-dom": "^2.0.1",
+    "@mongodb-js/charts-embed-dom": "^2.1.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-scripts": "3.4.1"

--- a/examples/unauthenticated/package-lock.json
+++ b/examples/unauthenticated/package-lock.json
@@ -986,25 +986,26 @@
       "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg=="
     },
     "@looker/chatty": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@looker/chatty/-/chatty-2.2.0.tgz",
-      "integrity": "sha512-+4KJI0ACVFX/r7KY4MyTXOqbEq0sSV+n8N2hRA0Kq+FJ6VxM5PpwSG8R5QEe4MuT3hNMV3H/kkX2NlFMvtnS8w==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@looker/chatty/-/chatty-2.3.0.tgz",
+      "integrity": "sha512-UO7pwQ+KU4UoV3+MSq7YVnWR74Pl1Jj15QO821W8Y+pW431KoHydiA7UUJmQnPEJDCgHLxepPs43jvJI/NMRhQ==",
       "requires": {
-        "core-js": "^3.1.4",
+        "core-js": "^3.6.4",
         "debug": "^2.2.0",
-        "es6-promise": "^4.2.5"
+        "es6-promise": "^4.2.8"
       }
     },
     "@mongodb-js/charts-embed-dom": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/charts-embed-dom/-/charts-embed-dom-2.0.1.tgz",
-      "integrity": "sha512-xd5PeWk7ds3K9Sv2HbpHumsbPmsXTBQXYtBedx18pz9y7AbTM83RjEvmF+5D0h3F+ZtGzNFGzE782oaWTxS1NQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/charts-embed-dom/-/charts-embed-dom-2.1.0.tgz",
+      "integrity": "sha512-F3/8lzmEUgcm5JdXRVsRzIuUgnO5DQvGrL39R6mtPOAUYhSF5zIXXF9cyuyQ1ti96aWLL35LJOzaAlh3CE0pXg==",
       "requires": {
-        "@babel/runtime": "^7.10.4",
+        "@babel/runtime": "^7.12.13",
         "@looker/chatty": "^2.2.0",
         "@types/bson": "^4.0.1",
-        "bson": "^4.0.2",
-        "jsonwebtoken": "^8.5.1"
+        "bson": "4.0.2",
+        "jsonwebtoken": "^8.5.1",
+        "lodash": "^4.17.19"
       }
     },
     "@mrmlnc/readdir-enhanced": {
@@ -1067,17 +1068,17 @@
       }
     },
     "@types/bson": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.3.tgz",
-      "integrity": "sha512-mVRvYnTOZJz3ccpxhr3wgxVmSeiYinW+zlzQz3SXWaJmD1DuL05Jeq7nKw3SnbKmbleW5qrLG5vdyWe/A9sXhw==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.5.tgz",
+      "integrity": "sha512-vVLwMUqhYJSQ/WKcE60eFqcyuWse5fGH+NMAXHuKrUAPoryq3ATxk5o4bgYNtg5aOM4APVg7Hnb3ASqUYG0PKg==",
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/node": {
-      "version": "14.14.25",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.25.tgz",
-      "integrity": "sha512-EPpXLOVqDvisVxtlbvzfyqSsFeQxltFbluZNRndIb8tr9KiBnYNLzrc1N3pyKUCww2RNrfHDViqDWWE1LCJQtQ=="
+      "version": "16.4.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.10.tgz",
+      "integrity": "sha512-TmVHsm43br64js9BqHWqiDZA+xMtbUpI1MBIA0EyiBmoV9pcEYFOSdj5fr6enZNfh4fChh+AGOLIzGwJnkshyQ=="
     },
     "@types/q": {
       "version": "1.5.4",
@@ -1598,11 +1599,12 @@
       }
     },
     "bson": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.2.2.tgz",
-      "integrity": "sha512-9fX257PVHAUpiRGmY3356RVWKQxLA73BgjA/x5MGuJkTEMeG7yzjuBrsiFB67EXRJnFVKrbJY9t/M+oElKYktQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.0.2.tgz",
+      "integrity": "sha512-rBdCxMBCg2aR420e1oKUejjcuPZLTibA7zEhWAlliFWEwzuBCC9Dkp5r7VFFIQB2t1WVsvTbohry575mc7Xw5A==",
       "requires": {
-        "buffer": "^5.6.0"
+        "buffer": "^5.1.0",
+        "long": "^4.0.0"
       }
     },
     "buffer": {
@@ -1913,9 +1915,9 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
     "core-js": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.8.3.tgz",
-      "integrity": "sha512-KPYXeVZYemC2TkNEkX/01I+7yd+nX3KddKwZ1Ww7SKWdI2wQprSgLmrTddT8nw92AjEklTsPBoSdQBhbI1bQ6Q=="
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.0.tgz",
+      "integrity": "sha512-5+5VxRFmSf97nM8Jr2wzOwLqRo6zphH2aX+7KsAUONObyzakDNq2G/bgbhinxB4PoV9L3aXQYhiDKyIKWd2c8g=="
     },
     "core-js-compat": {
       "version": "3.8.3",
@@ -3815,6 +3817,11 @@
       "requires": {
         "chalk": "^2.0.1"
       }
+    },
+    "long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
     "magic-string": {
       "version": "0.22.5",

--- a/examples/unauthenticated/package.json
+++ b/examples/unauthenticated/package.json
@@ -8,7 +8,7 @@
     "build": "parcel build index.html"
   },
   "dependencies": {
-    "@mongodb-js/charts-embed-dom": "^2.0.1",
+    "@mongodb-js/charts-embed-dom": "^2.1.0",
     "parcel": "^1.12.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Update all samples to use the newly-released SDK v2.1.0.
Demonstrates `setHighlight` in the two Click Events samples.