### PR TITLE
fix: CHARTS-6167 update embed chart sdk unauthenticated example

### DIFF
--- a/examples/unauthenticated/index.html
+++ b/examples/unauthenticated/index.html
@@ -26,11 +26,11 @@
         <label
           ><span>REFRESH INTERVAL </span>
           <select id="refresh-interval">
-            <option value="0">None</option>
+            <option value="-1">None</option>
             <option value="10">10 Seconds</option>
             <option value="60"><span>1 Minute</span></option>
-            <option value="1000">10 Minutes</option>
-            <option value="6000"><span>1 Hour</span></option>
+            <option value="600">10 Minutes</option>
+            <option selected value="3600"><span>1 Hour</span></option>
           </select>
         </label>
         <label
@@ -61,8 +61,8 @@
           <h3 class="chart-title">CHART DATA</h3>
           <table>
             <tr>
-              <th>Current Refresh Interval</th>
-              <td id="currentRefreshInterval">None</td>
+              <th>Current Refresh Interval (in secs)</th>
+              <td id="currentRefreshInterval">3600</td>
             </tr>
             <tr>
               <th>Current Theme</th>

--- a/examples/unauthenticated/src/index.js
+++ b/examples/unauthenticated/src/index.js
@@ -21,12 +21,11 @@ async function renderChart() {
   });
 
   /*
-    chart.setRefreshInterval(interval: number)
-    The default rate is to never refresh after rendering.
+    chart.setMaxDataAge(interval: number)
+    The default rate is to auto refresh every 1 hour.
     The minimum rate is every 10 seconds.
-    Setting to 0 returns the chart to the default setting.
 
-    chart.getRefreshInterval()
+    chart.getMaxDataAge()
     Returns a number pertaining to the charts current
     refresh interval.
    */
@@ -35,13 +34,12 @@ async function renderChart() {
     .addEventListener("change", async (e) => {
       var refreshInterval = e.target.value;
       refreshInterval
-        ? chart.setRefreshInterval(Number(refreshInterval))
-        : chart.setRefreshInterval(0);
+        ? chart.setMaxDataAge(Number(refreshInterval))
+        : chart.setMaxDataAge(3600);
 
-      var currentRefreshInterval = await chart.getRefreshInterval();
-      document.getElementById(
-        "currentRefreshInterval"
-      ).innerText = currentRefreshInterval;
+      var currentRefreshInterval = await chart.getMaxDataAge();
+      document.getElementById("currentRefreshInterval").innerText =
+        currentRefreshInterval;
     });
 
   /*


### PR DESCRIPTION
Updated unauthenticated example:
- Replace deprecated setRefreshInterval and getRefreshInterval with setMaxDataAge and getMaxDataAge
- Update default refresh settings
- Update option values to align with the label.