### PR TITLE
doc: Add link to API reference + React example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ yarn add @mongodb-js/charts-embed-dom
 - [Getting started with click events](https://github.com/mongodb-js/charts-embed-sdk/tree/master/examples/charts/click-events-basic)
 - [Interactive filtering using click events](https://github.com/mongodb-js/charts-embed-sdk/tree/master/examples/charts/click-events-filtering)
 - [Programmatic highlighting](https://github.com/mongodb-js/charts-embed-sdk/tree/master/examples/charts/programmatic-highlighting)
+- [Timeline Chart (React Example)](https://github.com/mongodb-js/charts-embed-sdk/tree/master/examples/charts/timeline-charts-example)
 
 ### Embedded Dashboard Guides
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ yarn add @mongodb-js/charts-embed-dom
 ## Documentation 📖
 
 - [Installation & MongoDB Docs](https://docs.mongodb.com/charts/master/embedding-charts-sdk/)
+- [Embedding SDK API Reference](https://www.npmjs.com/package/@mongodb-js/charts-embed-dom)
 - [Examples](https://github.com/mongodb-js/charts-embed-sdk/tree/master/examples)
 
 ### Embedded Chart Guides


### PR DESCRIPTION
Quick PR to add links to:
- npm page that has an exhaustive list of all the api methods documented nicely
- An existing React example for people who want to use the the charts embed SDK in a React application.